### PR TITLE
Use buffer-file-name instead of buffer-name

### DIFF
--- a/flymake-eslint.el
+++ b/flymake-eslint.el
@@ -3,6 +3,7 @@
 ;;; Version: 1.3.2
 
 ;;; Author: Dan Orzechowski
+;;; Contributor: Terje Larsen
 
 ;;; URL: https://github.com/orzechowskid/flymake-eslint
 

--- a/flymake-eslint.el
+++ b/flymake-eslint.el
@@ -113,7 +113,7 @@ Create linter process for SOURCE-BUFFER which invokes CALLBACK once linter is fi
          :connection-type 'pipe
          :noquery t
          :buffer (generate-new-buffer " *flymake-eslint*")
-         :command (list flymake-eslint-executable-name "--no-color" "--no-ignore" "--stdin" "--stdin-filename" (buffer-name source-buffer) (or flymake-eslint-executable-args ""))
+         :command (list flymake-eslint-executable-name "--no-color" "--no-ignore" "--stdin" "--stdin-filename" (buffer-file-name source-buffer) (or flymake-eslint-executable-args ""))
          :sentinel (lambda (proc &rest ignored)
                      ;; do stuff upon child process termination
                      (when (and (eq 'exit (process-status proc))


### PR DESCRIPTION
Use buffer-file-name which will return the full path file name which
should be compatible with --stdin-filename

Fixes #15