### PR TITLE
Fix compilation warning in Emacs 29

### DIFF
--- a/flymake-eslint.el
+++ b/flymake-eslint.el
@@ -172,7 +172,7 @@ argument."
                       ,(buffer-file-name source-buffer)
                       ,@(flymake-eslint--executable-args))
            :sentinel
-           (lambda (proc &rest ignored)
+           (lambda (proc &rest _ignored)
              ;; do stuff upon child process termination
              (when (and (eq 'exit (process-status proc))
                         ;; make sure we're not using a deleted buffer


### PR DESCRIPTION
Fix a compilation warning in Emacs 29 about the unused lexical argument `ignored'.