### PR TITLE
Prefer locally installed eslint when looking for the executable

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+;;; Directory Local Variables            -*- no-byte-compile: t -*-
+;;; For more information see (info "(emacs) Directory Variables")
+
+((emacs-lisp-mode . ((eval . (indent-tabs-mode 0)))))

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Flymake backend for Javascript using eslint
 
 ## Installation
 
-0. Make sure `eslint` is installed and present on your emacs `exec-path`.  For Linux systems `exec-path` usually equals your `$PATH` environment variable; for other systems, you're on your own.
+0. Make sure `eslint` is installed either globally and present on your Emacs `exec-path` or present in your project `node_modules/.bin` directory.  For Linux systems `exec-path` usually equals your `$PATH` environment variable; for other systems, you're on your own.
 1. Install:
   - from MELPA: `M-x package-install [RET] flymake-eslint [RET]`
   - manually: download and place inside `~/.emacs.d/lisp` then edit `~/.emacs` or equivalent:
@@ -49,6 +49,11 @@ Useful when the value of variable `exec-path' is set dynamically and the locatio
 (defcustom flymake-eslint-project-root nil
   "Buffer-local.  Set to a filesystem path to use that path as the current working directory of the linting process."
   :type 'string
+  :group 'flymake-eslint)
+
+(defcustom flymake-eslint-prefer-global nil
+  "Prefer a globally installed ESLint when looking for the executable."
+  :type 'boolean
   :group 'flymake-eslint)
 ```
 


### PR DESCRIPTION
Thanks for this package! I find it very useful on my day to day.

I had some free time so I decided to implement #26.

This will prefer the locally installed executable, but will fallback to the global one if there is no local installation. This behavior can also be reversed by setting the `flymake-eslint-prefer-global` custom option.