### PR TITLE
Run eslint from project root

### DIFF
--- a/flymake-eslint.el
+++ b/flymake-eslint.el
@@ -26,6 +26,7 @@
 ;;;; Requirements
 
 (require 'cl-lib)
+(require 'project)
 
 ;;;; Customization
 
@@ -160,7 +161,10 @@ CALLBACK accepts a buffer containing stdout from linter as its
 argument."
   (when (process-live-p flymake-eslint--process)
     (kill-process flymake-eslint--process))
-  (let ((default-directory (or flymake-eslint-project-root default-directory)))
+  (let ((default-directory
+         (if (project-current)
+             (project-root (project-current))
+             default-directory)))
     (setq flymake-eslint--process
           (make-process
            :name "flymake-eslint"


### PR DESCRIPTION
The current proposed solution for #19 works fine, but I think there are a couple issues:

- First, I think it would be better if it worked out of the box. At least for me, it took me by surprise and at first I thought it was a configuration problem with the project rather than the package.
- It is another iteration of "Finding the root of a project". Emacs already has a builtin solution for this in the form of the `project` package

So this MR tries to run eslint from the project root found by `project` and fall-backs to the default directory if not inside a project.