### PR TITLE
Prevent crash when running on non-file buffer

### DIFF
--- a/flymake-eslint.el
+++ b/flymake-eslint.el
@@ -249,7 +249,7 @@ argument."
                       ,@format-args
                       "--stdin"
                       "--stdin-filename"
-                      ,(buffer-file-name source-buffer)
+                      ,(or (buffer-file-name source-buffer) (buffer-name source-buffer))
                       ,@(flymake-eslint--executable-args))
            :sentinel
            (lambda (proc &rest ignored)


### PR DESCRIPTION
Sometimes flymake-eslint is started on a buffer that is not baked by a
file (e.g., *scratch*, an ediff buffer or an old version of a
git-versioned file). In this case, `buffer-file-name' returns nil
which is invalid for a command list.